### PR TITLE
fix: wrong doctype include of pos_profile.js and fix 404 error because wrong including of form-raw.min.js

### DIFF
--- a/pasigono/hooks.py
+++ b/pasigono/hooks.py
@@ -14,7 +14,7 @@ app_license = "MIT"
 
 # include js, css files in header of desk.html
 # app_include_css = "/assets/pasigono/css/pasigono.css"
-app_include_js = ["/assets/js/form-raw.min.js", "https://js.stripe.com/terminal/v1/", 
+app_include_js = ["form-raw.bundle.js", "https://js.stripe.com/terminal/v1/",
 					"/assets/pasigono/js/jsrsasign-all-min.js", "pos-mettler-toledo.bundle.js"]
 
 # include js, css files in header of web template
@@ -32,7 +32,7 @@ app_include_js = ["/assets/js/form-raw.min.js", "https://js.stripe.com/terminal/
 page_js = {"point-of-sale" : "custom_scripts/point_of_sale/point_of_sale.js"}
 
 # include js in doctype views
-doctype_js = {"pos_profile" : "custom_scripts/pos_profile/pos_profile.js"}
+doctype_js = {"POS Profile" : "custom_scripts/pos_profile/pos_profile.js"}
 # doctype_list_js = {"doctype" : "public/js/doctype_list.js"}
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}

--- a/pasigono/public/js/form-raw.bundle.js
+++ b/pasigono/public/js/form-raw.bundle.js
@@ -1,0 +1,1 @@
+import "../../custom_scripts/frappe/form.js";


### PR DESCRIPTION
We got an 404 error in the browser console because of form-raw.min.js and the pos_profile.js didn't execute in the POS Profile doctype.